### PR TITLE
Fix: Changed package to support SBT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.noorq.casser</groupId>
-	<artifactId>casser-core</artifactId>
-	<version>1.2.0_2.11-SNAPSHOT</version>
+	<artifactId>casser-core_2.11</artifactId>
+	<version>1.2.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>casser</name>


### PR DESCRIPTION
When you want to use the package from SBT in a way that you
normally would use scala package the package needs to have
a name like casser-core_2.11.

This fixes issue #1
